### PR TITLE
Switch away from descriptors and improve type info

### DIFF
--- a/src/gradle-plugin/build.gradle.kts
+++ b/src/gradle-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.kapt3.base.Kapt.kapt
 
 group = "com.josephdwyer.katana"
 base.archivesBaseName = "gradle-plugin"
-version = "0.0.22"
+version = "0.0.23"
 
 repositories {
     maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }

--- a/src/gradle-plugin/src/main/kotlin/com/josephdwyer/katana/gradle/KatanaSubplugin.kt
+++ b/src/gradle-plugin/src/main/kotlin/com/josephdwyer/katana/gradle/KatanaSubplugin.kt
@@ -47,7 +47,7 @@ class KatanaSubplugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
         groupId = "com.josephdwyer.katana",
         artifactId = "jvm-katana-compiler-plugin",
-        version = "0.0.3"
+        version = "0.0.2"
     )
 
     // This points to our native plugin that is published on bintray

--- a/src/gradle-plugin/src/main/kotlin/com/josephdwyer/katana/gradle/KatanaSubplugin.kt
+++ b/src/gradle-plugin/src/main/kotlin/com/josephdwyer/katana/gradle/KatanaSubplugin.kt
@@ -47,7 +47,7 @@ class KatanaSubplugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
         groupId = "com.josephdwyer.katana",
         artifactId = "jvm-katana-compiler-plugin",
-        version = "0.0.2"
+        version = "0.0.3"
     )
 
     // This points to our native plugin that is published on bintray
@@ -55,7 +55,7 @@ class KatanaSubplugin : KotlinGradleSubplugin<AbstractCompile> {
     override fun getNativeCompilerPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
         groupId = "com.josephdwyer.katana",
         artifactId = "katana-compiler-plugin",
-        version = "0.0.2"
+        version = "0.0.3"
     )
 }
 

--- a/src/jvm-plugin/build.gradle.kts
+++ b/src/jvm-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ import java.util.Date
 // so that compiling projects with JVM things will work
 
 group = "com.josephdwyer.katana"
-version = "0.0.2"
+version = "0.0.3"
 base.archivesBaseName = "jvm-katana-compiler-plugin"
 
 repositories {

--- a/src/jvm-plugin/build.gradle.kts
+++ b/src/jvm-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ import java.util.Date
 // so that compiling projects with JVM things will work
 
 group = "com.josephdwyer.katana"
-version = "0.0.3"
+version = "0.0.2"
 base.archivesBaseName = "jvm-katana-compiler-plugin"
 
 repositories {

--- a/src/native-plugin/build.gradle.kts
+++ b/src/native-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.util.Date
 
 group = "com.josephdwyer.katana"
-version = "0.0.2"
+version = "0.0.3"
 base.archivesBaseName = "katana-compiler-plugin"
 
 repositories {

--- a/src/native-plugin/src/main/kotlin/com/josephdwyer/katana/CollectDataExtension.kt
+++ b/src/native-plugin/src/main/kotlin/com/josephdwyer/katana/CollectDataExtension.kt
@@ -94,10 +94,13 @@ private class OnFunction(val context: IrPluginContext) : IrElementTransformerVoi
 
     private fun tryAddClassJson(irClass: IrClass?) {
         if (irClass != null && shouldIncludeClass(irClass)) {
-            classes.putIfAbsent(irClass.fqNameWhenAvailable.toString(), getClassJson(irClass))
-
-            for (superType in irClass.superTypes) {
-                tryAddClassJson(superType.getClass())
+            val fqn = irClass.fqNameWhenAvailable.toString()
+            if (!classes.containsKey(fqn))
+            {
+                classes[fqn] = getClassJson(irClass)
+                for (superType in irClass.superTypes) {
+                    tryAddClassJson(superType.getClass())
+                }
             }
         }
     }

--- a/src/native-plugin/src/main/kotlin/com/josephdwyer/katana/CollectDataExtension.kt
+++ b/src/native-plugin/src/main/kotlin/com/josephdwyer/katana/CollectDataExtension.kt
@@ -7,21 +7,16 @@ import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.ir.allParameters
 import org.jetbrains.kotlin.backend.common.runOnFilePostfix
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrFunction
-import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import org.jetbrains.kotlin.ir.declarations.path
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.types.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
-import org.jetbrains.kotlin.js.descriptorUtils.getJetTypeFqName
 import org.jetbrains.kotlin.konan.file.File
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.jetbrains.kotlin.types.typeUtil.nullability
 
 open class CollectDataExtension(private val configuration: CompilerConfiguration) : IrGenerationExtension {
 
-    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext)    {
+    override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
         val visitor = OnFunction(pluginContext)
 
         for (file in moduleFragment.files) {
@@ -29,10 +24,11 @@ open class CollectDataExtension(private val configuration: CompilerConfiguration
         }
 
         // for some reason this is called 2 times, one without any data
-        if (visitor.collected.any()) {
+        if (visitor.functions.any()) {
             configuration[OUTPUT_FILE]?.let {
+                val katanaJson = KatanaJson(visitor.classes, visitor.functions)
                 val gson = GsonBuilder().setPrettyPrinting().create()
-                val data = gson.toJson(visitor.collected)
+                val data = gson.toJson(katanaJson)
                 File(it).writeText(data)
                 println("Katana data written to $it")
             }
@@ -40,18 +36,14 @@ open class CollectDataExtension(private val configuration: CompilerConfiguration
     }
 }
 
-private class OnFunction(
-        val context: IrPluginContext
-) :
-        IrElementTransformerVoid(), FunctionLoweringPass {
+private class OnFunction(val context: IrPluginContext) : IrElementTransformerVoid(), FunctionLoweringPass {
 
-    val collected = mutableListOf<FunctionJson>()
+    val functions = mutableListOf<FunctionJson>()
+    val classes = mutableMapOf<String, ClassJson>()
 
     override fun lower(irFunction: IrFunction) {
 
-        val visibility = irFunction.visibility.toString()
-        if (visibility != "public") {
-            // we only care about public ones
+        if (!shouldIncludeFunction(irFunction)) {
             return
         }
 
@@ -59,81 +51,35 @@ private class OnFunction(
         val startLine = irFunction.fileEntry.getLineNumber(irFunction.startOffset)
         val endLine = irFunction.fileEntry.getLineNumber(irFunction.endOffset)
 
-
         val file = FileJson(irFunction.file.path, startLine, endLine)
 
         val functionName = irFunction.name.toString()
 
         val parameters = irFunction.allParameters.map { parameter ->
-            val type = parameter.type as IrSimpleType
-            val typeAsClass = parameter.type.getClass()?.let { getClassInfo(it) }
-
-            val typeParameters = type.toKotlinType()
-                    .arguments
-                    .map {
-                        val typeNullability = it.type.nullability()
-                        val typeName = it.type.getJetTypeFqName(true)
-                        TypeParameterJson(typeName, typeNullability)
-                    }
+            tryAddClassJson(parameter.type.getClass())
 
             FunctionParameterJson(
                     parameter.name.toString(),
-                    TypeJson(type.classifier.descriptor.fqNameSafe.toString(), typeParameters, type.isNullable(), typeAsClass))
+                    getTypeJson(parameter.type as IrSimpleType))
         }
 
-        val returnTypeTypeParameters = irFunction.returnType.toKotlinType()
-                .arguments
-                .map {
-                    val returnTypeNullability = it.type.nullability()
-                    val typeName = it.type.getJetTypeFqName(true)
-                    TypeParameterJson(typeName, returnTypeNullability)
-                }
+        val returnType = getTypeJson(irFunction.returnType as IrSimpleType)
 
-        val returnTypeClass = irFunction.returnType.getClass()?.let {
-            getClassInfo(it)
-        }
+        val parentClass = irFunction.parentClassOrNull
 
-        val returnType = TypeJson(
-                irFunction.returnType.classifierOrNull?.descriptor?.fqNameSafe?.toString() ?: "Unit",
-                returnTypeTypeParameters,
-                irFunction.returnType.isNullable(),
-                returnTypeClass)
+        tryAddClassJson(irFunction.returnType.getClass())
+        tryAddClassJson(parentClass)
 
-        val classInfo = irFunction.parentClassOrNull?.let { getClassInfo(it) }
+        val function = FunctionJson(file, getPackage(irFunction), functionName,
+                irFunction.visibility.toString(), parameters, returnType,
+                parentClass?.fqNameForIrSerialization?.toString(), irFunction is IrConstructor)
 
-        // maybe a simpler way to get the package?
-        // irFunction.file.packageFragmentDescriptor
-
-        // if this function is in a class, just take the class's package
-        // otherwise it is the fully qualified name minus the function's name
-        val packageName = classInfo?.let { it.packageName } ?:
-        irFunction.fqNameWhenAvailable.toString()
-                .removeSuffix(irFunction.name.toString())
-                .removeSuffix(".")
-
-        var parent: String = irFunction.parent.let {
-            it.fqNameForIrSerialization.toString()
-        }
-
-        val function = FunctionJson(file, packageName, functionName,
-                visibility, parameters, returnType,
-                parent, classInfo, irFunction.isExpect)
-
-        collected.add(function)
+        functions.add(function)
     }
 
-    private fun getClassInfo(irClass: IrClass) : ClassJson {
-        // we are trying to remove ".className" from "some.namespace.className"
-        // but, if the class is not in a namespace (thus using the default "<root>" namespace
-        // there won't be any leading content - it will just be "className", so we need to remove in 2 stages
-        val packageName = irClass.fqNameWhenAvailable.toString()
-                .removeSuffix(irClass.name.toString())
-                .removeSuffix(".")
-
-        // should we default it to "<root>" if it is now empty or leave it to the consumer?
-
+    private fun getClassJson(irClass: IrClass): ClassJson {
         val superTypes = irClass.superTypes.map {
-            (it.classifierOrNull?.descriptor?.fqNameSafe.toString())
+            getTypeJson(it as IrSimpleType)
         }
 
         return ClassJson(
@@ -141,9 +87,60 @@ private class OnFunction(
                 irClass.isCompanion,
                 irClass.isData,
                 irClass.isInline,
-                irClass.isExpect,
                 irClass.kind,
                 superTypes,
-                packageName)
+                getPackage(irClass))
+    }
+
+    private fun tryAddClassJson(irClass: IrClass?) {
+        if (irClass != null && shouldIncludeClass(irClass)) {
+            classes.putIfAbsent(irClass.fqNameWhenAvailable.toString(), getClassJson(irClass))
+
+            for (superType in irClass.superTypes) {
+                tryAddClassJson(superType.getClass())
+            }
+        }
+    }
+
+    private fun shouldIncludeClass(irClass: IrClass): Boolean {
+        // we only care about public actual ones
+        return !irClass.isExpect && irClass.visibility.toString() == "public"
+    }
+
+    private fun shouldIncludeFunction(irFunction: IrFunction): Boolean {
+        // we only care about public actual ones whose classes are also public and actual
+        val parentClass = irFunction.parentClassOrNull
+        return !irFunction.isExpect &&
+                irFunction.visibility.toString() == "public" &&
+                (parentClass == null || shouldIncludeClass(parentClass))
+    }
+
+    private fun getPackage(irElement: IrElement): String {
+        return irElement.getPackageFragment()?.fqNameForIrSerialization.toString()
+    }
+
+    private fun getFullyQualifiedName(irSimpleType: IrSimpleType): String {
+        return (irSimpleType.classifier.owner as IrDeclarationWithName).fqNameWhenAvailable.toString()
+    }
+
+    private fun getTypeArgumentJson(type: IrTypeArgument): TypeArgumentJson {
+        return when (type) {
+            is IrStarProjection -> TypeArgumentJson(isStar = true, null, null)
+            is IrTypeProjection -> {
+                val projectedType = type.type as IrSimpleType
+                TypeArgumentJson(isStar = false, getTypeJson(projectedType), type.variance.label)
+            }
+            else -> throw AssertionError("Unexpected type argument $type ${type.render()}")
+        }
+    }
+
+    private fun getTypeArguments(type: IrSimpleType): List<TypeArgumentJson> {
+        return type.arguments.map { getTypeArgumentJson(it) }
+    }
+
+    private fun getTypeJson(type: IrSimpleType): TypeJson {
+        val nullable = type.isNullable()
+        val typeName = getFullyQualifiedName(type)
+        return TypeJson(typeName, getTypeArguments(type), nullable)
     }
 }

--- a/src/native-plugin/src/main/kotlin/com/josephdwyer/katana/Json.kt
+++ b/src/native-plugin/src/main/kotlin/com/josephdwyer/katana/Json.kt
@@ -1,8 +1,11 @@
 package com.josephdwyer.katana
 
 import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.types.typeUtil.TypeNullability
 
+data class KatanaJson(
+        val classes: Map<String, ClassJson>,
+        val functions: List<FunctionJson>
+)
 
 data class FileJson(
         val filePath: String,
@@ -15,16 +18,18 @@ data class FunctionParameterJson(
         val type: TypeJson
 )
 
-data class TypeParameterJson(
-        val type: String,
-        val nullability: TypeNullability
+// Type arguments for specific references to classes, e.g. Int for List<Int> or * for List<*>
+data class TypeArgumentJson(
+        val isStar: Boolean,
+        val type: TypeJson?,
+        val variance: String?
 )
 
+// Concrete types, e.g. List<Int>
 data class TypeJson(
         val name: String,
-        val typeParameters: List<TypeParameterJson>,
-        val nullable: Boolean,
-        val classInfo: ClassJson?
+        val typeArguments: List<TypeArgumentJson>,
+        val nullable: Boolean
 )
 
 data class ClassJson(
@@ -32,9 +37,8 @@ data class ClassJson(
         val isCompanion: Boolean,
         val isData: Boolean,
         val isInline: Boolean,
-        val isExpect: Boolean,
         val kind: ClassKind,
-        val superClasses: List<String>,
+        val superClasses: List<TypeJson>,
         val packageName: String
 )
 
@@ -45,7 +49,6 @@ data class FunctionJson(
         val visibility: String,
         val parameters: List<FunctionParameterJson>?,
         val returnType: TypeJson,
-        val parent: String,
-        val classInfo: ClassJson?,
-        val isExpect: Boolean
+        val parentClass: String?,
+        val isConstructor: Boolean
 )


### PR DESCRIPTION
Use IR representations to get names of all entities. This actually turned out to be a little trickier than expected, since before we were getting less accurate answers in some cases (e.g. `Any?` instead of `*`), which pushed me towards reorganizing things a little bit.

Upgrade `TypeParameterJson` to support star projections and variance, as well as an object for the type in order to support nested generics. Also rename to `TypeArgumentJson` to match the IR terminology ("type parameter" for a generic type T, "type argument" for a specific type that's bound to a parameter).

Also move class information out of `TypeJson` to reduce redundancy, espcially with the additional use of `TypeJson` in `TypeArgumentJson` and `ClassJson`; instead build a map of fully-qualified name to `ClassInfo`. Note that an `expect class` and an `actual class` have the same FQN, but since we only care about actual classes at the moment, we can simply ignore the expect classes when generating the JSON. Functions' parent classes, parameters, and return values (as well as their supertypes) are added to the map as we go.

`ClassJson` now also has a full `TypeJson` record for its supertypes, while `FunctionJson` merely keeps a string reference to the FQN of its associated class, if any. Instead of having one parent which could be a class or a package, we'll be more explicit now.

As a nice payoff, the actual `OnFunction` body mostly gets simpler due to some new recursive helpers.