### PR TITLE
move to MavenCentral

### DIFF
--- a/src/gradle-plugin/build.gradle.kts
+++ b/src/gradle-plugin/build.gradle.kts
@@ -2,10 +2,9 @@ import org.jetbrains.kotlin.kapt3.base.Kapt.kapt
 
 group = "com.josephdwyer.katana"
 base.archivesBaseName = "gradle-plugin"
-version = "0.0.26"
+version = "0.0.27"
 
 repositories {
-    maven { setUrl("https://dl.bintray.com/kotlin/kotlin-eap") }
     mavenCentral()
 }
 

--- a/src/gradle-plugin/src/main/kotlin/com/josephdwyer/katana/gradle/KatanaPlugin.kt
+++ b/src/gradle-plugin/src/main/kotlin/com/josephdwyer/katana/gradle/KatanaPlugin.kt
@@ -33,7 +33,7 @@ class KatanaPlugin : KotlinCompilerPluginSupportPlugin {
     // This points to our JVM plugin that is published on bintray
     // If you publish a new version, you need to manually bump the version here
     override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
-        groupId = "com.josephdwyer.katana",
+        groupId = "com.joseph-dwyer.katana",
         artifactId = "jvm-katana-compiler-plugin",
         version = "0.0.2"
     )
@@ -41,7 +41,7 @@ class KatanaPlugin : KotlinCompilerPluginSupportPlugin {
     // This points to our native plugin that is published on bintray
     // If you publish a new version, you need to manually bump the version here
     override fun getPluginArtifactForNative(): SubpluginArtifact = SubpluginArtifact(
-        groupId = "com.josephdwyer.katana",
+        groupId = "com.joseph-dwyer.katana",
         artifactId = "katana-compiler-plugin",
         version = "0.0.5"
     )


### PR DESCRIPTION
The native and jvm plugins are published to maven central with the same versions, but the group id changed from `com.josephdwyer` to `com.joseph-dwyer`

https://s01.oss.sonatype.org/service/local/repositories/releases/content/com/joseph-dwyer/katana/katana-compiler-plugin/0.0.5/

https://s01.oss.sonatype.org/service/local/repositories/releases/content/com/joseph-dwyer/katana/jvm-katana-compiler-plugin/0.0.2/